### PR TITLE
Prevent dot in exponent

### DIFF
--- a/src/hxjsonast/Parser.hx
+++ b/src/hxjsonast/Parser.hx
@@ -248,7 +248,7 @@ class Parser {
                     digit = true;
                     zero = false;
                 case '.'.code:
-                    if (minus || point)
+                    if (minus || point || e)
                         invalidNumber(start);
                     digit = false;
                     point = true;


### PR DESCRIPTION
As in the Haxe repository, mark exponent with a dot as invalid, to follow the json specification.