### PR TITLE
Unclosed string error when parsing some unicode character

### DIFF
--- a/src/hxjsonast/Parser.hx
+++ b/src/hxjsonast/Parser.hx
@@ -198,7 +198,7 @@ class Parser {
                 }
                 start = pos;
             }
-            #if (neko || php || cpp)
+            #if (neko || (!haxe4 && (php || cpp)))
             // ensure utf8 chars are not cut
             else if (c >= 0x80) {
                 pos++;


### PR DESCRIPTION
Hello,

There is an issue in the parsing of some unicode character for php/cpp targets.

Calling `Parser.parse('"á"', '')` using php or cpp will yield an "Unclosed string exception".

I think this is similar to #10 as removing it for haxe4 fixes the problem.